### PR TITLE
Change deploy logic to not use hard-coded frogcms database

### DIFF
--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -17,7 +17,7 @@ then
 fi
 
 # Confirm database exists, if not create it
-if ! /usr/bin/mysql -u "$OPENSHIFT_MYSQL_DB_USERNAME" --password="$OPENSHIFT_MYSQL_DB_PASSWORD" -h "$OPENSHIFT_MYSQL_DB_HOST" -e "select * from user;" frogcms > /dev/null 2>&1
+if ! /usr/bin/mysql -u "$OPENSHIFT_MYSQL_DB_USERNAME" --password="$OPENSHIFT_MYSQL_DB_PASSWORD" -h "$OPENSHIFT_MYSQL_DB_HOST" -e "select * from user;" $OPENSHIFT_APP_NAME > /dev/null 2>&1
 then
     echo
     echo "Database schema not found, importing 'frogcms.sql' schema."


### PR DESCRIPTION
Now it will use `$OPENSHIFT_APP_NAME` in case the user names the application differently